### PR TITLE
env variable support + fallback, better error handling and cargo optimizations  + github actions and more documentation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "geoiplocation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["sn99 <siddharthn.099@gmail.com>"]
 description = "Get location based on IP"
-keywords = ["location", "ip"]
+keywords = ["location", "ip", "json"]
 readme = "README.md"
 license = "MIT"
 
@@ -14,6 +14,12 @@ license = "MIT"
 reqwest = { version = "0.11.10", features = ["json"] }
 tokio = {version="1.19.2", features =["full"]}
 serde = {version="1.0.137", features = ["derive"]}
+anyhow = "1.0.58"
 
 [env]
 LOCATION_API_URL = "https://www.loc.subcom.link/api/v1/iplocation"
+
+[profile.release]
+lto = true
+codegen-units = 1
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ license = "MIT"
 reqwest = { version = "0.11.10", features = ["json"] }
 tokio = {version="1.19.2", features =["full"]}
 serde = {version="1.0.137", features = ["derive"]}
+
+[env]
+LOCATION_API_URL = "https://www.loc.subcom.link/api/v1/iplocation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = {version="1.0.137", features = ["derive"]}
 anyhow = "1.0.58"
 
 [env]
-LOCATION_API_URL = "https://www.loc.subcom.link/api/v1/iplocation"
+SUBCOM_LOCATION_API_URL = "https://www.loc.subcom.link/api/v1/iplocation"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 authors = ["sn99 <siddharthn.099@gmail.com>"]
 description = "Get location based on IP"
-keywords = ["location", "ip", "json"]
+keywords = ["location", "ip", "json", "get"]
 readme = "README.md"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Find location given the IP address.
 Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the
 given query.
 
-You can set your own env for location api using something like `export LOCATION_API_URL=<your-url>`
+You can set your own env for location api using something like `export SUBCOM_LOCATION_API_URL=<your-url>`
 The final URL looks something like `your-url/IP?apikey=KEY`.
 
 Two methods are provides(more documentation provided):

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Two methods are provides(more documentation provided):
 - `async fn get_location_fallback(ip: &str, key: &str) -> anyhow::Result<HashMap<String, String>>`
 
 **NOTE:** Still in production so a few things might break or change, you can use `cargo doc --open` for better
-experience or read it [here]().
+experience or read it [here](https://docs.rs/geoiplocation/latest/geoiplocation/index.html).
 
 Eg:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # geoiplocation
 Get location data for a given IP
 
-Find location given the IP address.Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the given query.
+Find location given the IP address.
+
+Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the
+given query.
+
+You can set your own env for location api using something like `export LOCATION_API_URL=<your-url>`
+The final URL looks something like `your-url/IP?apikey=KEY`.
+
+Two methods are provides(more documentation provided):
+
+- `async fn get_location(ip: &str, key: &str) -> anyhow::Result<Option<Location>>`
+- `async fn get_location_fallback(ip: &str, key: &str) -> anyhow::Result<HashMap<String, String>>`
+
+**NOTE:** Still in production so a few things might break or change, you can use `cargo doc --open` for better
+experience or read it [here]().
 
 Eg:
 

--- a/src/geoiplocation.rs
+++ b/src/geoiplocation.rs
@@ -2,6 +2,9 @@ use serde::Deserialize;
 
 /// Fields of the JSON response
 /// Everything is an `Option` in case it returns wrong or empty values
+///
+/// You can also use `get_location_fallback` in case the JSON response changes
+#[allow(dead_code)]
 #[derive(Deserialize, Debug, Clone)]
 pub struct Location {
     /// The ip we ask it to get data for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,14 @@
 //!
 //! Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the
 //! given query.
+//! You can set your own env for location api using something like `export LOCATION_API_URL=<your-url>`
+//! The final URL looks something like `your-url/IP?apikey=KEY`
 
 use crate::geoiplocation::Location;
 use reqwest::Url;
 
 pub mod geoiplocation;
+use std::env;
 
 /// `async` function to get the location
 ///
@@ -28,10 +31,12 @@ pub mod geoiplocation;
 /// }
 /// ```
 pub async fn get_location(
-    ip: String,
+    ip: &str,
     key: &str,
 ) -> Result<Option<Location>, Box<dyn std::error::Error>> {
-    let mut url = Url::parse(&*format!("http://65.1.118.229/api/v1/iplocation/{}", ip))?;
+    let location_api_url = env::var("LOCATION_API_URL").expect("cannot parse URL");
+
+    let mut url = Url::parse(&*format!("{}/{}", location_api_url, ip))?;
     url.set_query(Some(&*format!("apikey={}", key)));
 
     Ok(Some(reqwest::get(url).await?.json::<Location>().await?))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,17 @@
 //!
 //! Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the
 //! given query.
+//!
 //! You can set your own env for location api using something like `export LOCATION_API_URL=<your-url>`
-//! The final URL looks something like `your-url/IP?apikey=KEY`
+//! The final URL looks something like `your-url/IP?apikey=KEY`.
+//!
+//! Two methods are provides(more documentation provided):
+//!
+//! - `async fn get_location(ip: &str, key: &str) -> anyhow::Result<Option<Location>>`
+//! - `async fn get_location_fallback(ip: &str, key: &str) -> anyhow::Result<HashMap<String, String>>`
+//!
+//! **NOTE:** Still in production so a few things might break or change, you can use `cargo doc --open` for better
+//! experience or read it [here](https://docs.rs/geoiplocation/latest/geoiplocation/index.html).
 
 use crate::geoiplocation::Location;
 use reqwest::Url;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides abstraction over the fields returned by the JSON response. Returns a `Struct` for the
 //! given query.
 //!
-//! You can set your own env for location api using something like `export LOCATION_API_URL=<your-url>`
+//! You can set your own env for location api using something like `export SUBCOM_LOCATION_API_URL=<your-url>`
 //! The final URL looks something like `your-url/IP?apikey=KEY`.
 //!
 //! Two methods are provides(more documentation provided):
@@ -41,7 +41,7 @@ use std::env;
 /// }
 /// ```
 pub async fn get_location(ip: &str, key: &str) -> anyhow::Result<Option<Location>> {
-    let location_api_url = env::var("LOCATION_API_URL").expect("cannot parse URL");
+    let location_api_url = env::var("SUBCOM_LOCATION_API_URL").expect("cannot parse URL");
 
     let mut url = Url::parse(&*format!("{}/{}", location_api_url, ip))?;
     url.set_query(Some(&*format!("apikey={}", key)));
@@ -54,7 +54,7 @@ pub async fn get_location(ip: &str, key: &str) -> anyhow::Result<Option<Location
 /// Instead of holding the values in a Struct he hold the in `HashMap<String, String>`, this should
 /// provide a fallback in case the api is ever changing to keep on updating the struct
 pub async fn get_location_fallback(ip: &str, key: &str) -> anyhow::Result<HashMap<String, String>> {
-    let location_api_url = env::var("LOCATION_API_URL").expect("cannot parse URL");
+    let location_api_url = env::var("SUBCOM_LOCATION_API_URL").expect("cannot parse URL");
 
     let mut url = Url::parse(&*format!("{}/{}", location_api_url, ip))?;
     url.set_query(Some(&*format!("apikey={}", key)));


### PR DESCRIPTION
You can set the env `export LOCATION_API_URL=https://www.loc.subcom.link/api/v1/iplocation`